### PR TITLE
Upgrade driver interface to support batch operations

### DIFF
--- a/packages/fields-storage-mongodb/src/MongoDbDriver.js
+++ b/packages/fields-storage-mongodb/src/MongoDbDriver.js
@@ -17,34 +17,40 @@ class MongoDbDriver {
         };
     }
 
-    // eslint-disable-next-line
-    async save({ name, data, isCreate }) {
-        return isCreate ? this.create({ name, data }) : this.update({ name, data });
-    }
-
-    async create({ name, data }: Object) {
-        data._id = new mongodb.ObjectID(data.id);
-
-        await this.getDatabase()
-            .collection(this.getCollectionName(name))
-            .insertOne(data);
-        return true;
-    }
-
-    async update({ name, data }: Object) {
-        const collection = this.getCollectionName(name);
-        await this.getDatabase()
-            .collection(collection)
-            .updateOne({ id: data.id }, { $set: data });
+    async create(items: Array<Object>) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            data._id = new mongodb.ObjectID(data.id);
+            await this.getDatabase()
+                .collection(this.getCollectionName(name))
+                .insertOne(data);
+        }
 
         return true;
     }
 
+    async update(items: Array<Object>) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            const collection = this.getCollectionName(name);
+            await this.getDatabase()
+                .collection(collection)
+                .updateOne({ id: data.id }, { $set: data });
+        }
+
+        return true;
+    }
+
     // eslint-disable-next-line
-    async delete({ name, data: { id } }) {
-        await this.getDatabase()
-            .collection(this.getCollectionName(name))
-            .deleteOne({ id });
+    async delete(items: Array<Object>) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+
+            await this.getDatabase()
+                .collection(this.getCollectionName(name))
+                .deleteOne({ id: data.id });
+        }
+
         return true;
     }
 

--- a/packages/fields-storage-ref/__tests__/fields/ref/delete.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/ref/delete.test.js
@@ -148,7 +148,8 @@ describe("model delete test", () => {
 
         classA.classB = { name: "classB", classC: { name: "classC" } };
 
-        const saveSpy = sandbox.stub(classA.getStorageDriver(), "save");
+        const createSpy = sandbox.stub(classA.getStorageDriver(), "create");
+        const updateSpy = sandbox.stub(classA.getStorageDriver(), "update");
         const generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -157,10 +158,11 @@ describe("model delete test", () => {
             .callsFake(() => "classB");
 
         await classA.save();
-        saveSpy.restore();
+        updateSpy.restore();
         generateIdStub.restore();
 
-        expect(saveSpy.calledThrice).toBeTruthy();
+        expect(createSpy.callCount).toBe(2);
+        expect(updateSpy.callCount).toBe(1);
 
         expect(classA.id).toBe("classA");
 
@@ -198,7 +200,7 @@ describe("model delete test", () => {
         modelFindById.restore();
 
         const modelSave = sandbox
-            .stub(classADynamic.getStorageDriver(), "save")
+            .stub(classADynamic.getStorageDriver(), "update")
             .onCall(0)
             .callsFake(() => {
                 return true;

--- a/packages/fields-storage-ref/__tests__/fields/ref/dirty.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/ref/dirty.test.js
@@ -4,14 +4,13 @@ import mdbid from "mdbid";
 
 const sandbox = sinon.createSandbox();
 const getEntity = async () => {
-
     const id = mdbid();
 
     let modelFindById = sandbox
         .stub(One.getStorageDriver(), "findOne")
         .onCall(0)
         .callsFake(() => {
-            return ({ id, name: "One", two: "two" });
+            return { id, name: "One", two: "two" };
         });
 
     const model = await One.findById(id);
@@ -103,7 +102,7 @@ describe("dirty flag test", () => {
         expect(twoAttribute.state.dirty).toBe(false);
 
         let findById = sandbox.stub(One.getStorageDriver(), "findOne").callsFake(() => {
-            return ({ id: "two", name: "Two" });
+            return { id: "two", name: "Two" };
         });
 
         const two = await one.two;
@@ -120,25 +119,25 @@ describe("dirty flag test", () => {
         const one = await getEntity();
 
         let findById = sandbox.stub(One.getStorageDriver(), "findOne").callsFake(() => {
-            return ({ id: "two", name: "Two" });
+            return { id: "two", name: "Two" };
         });
 
         const two = await one.two;
         findById.restore();
 
-        const modelSaveSpy = sandbox.spy(One.getStorageDriver(), "save");
+        const modelUpdateSpy = sandbox.spy(One.getStorageDriver(), "update");
 
         await one.save();
-        expect(modelSaveSpy.callCount).toEqual(0);
+        expect(modelUpdateSpy.callCount).toEqual(0);
 
         two.name = "anotherName";
         expect(two.isDirty()).toBe(true);
         await one.save();
-        expect(modelSaveSpy.callCount).toEqual(1);
+        expect(modelUpdateSpy.callCount).toEqual(1);
         expect(!two.isDirty()).toBe(true);
 
         await one.save();
-        expect(modelSaveSpy.callCount).toEqual(1);
+        expect(modelUpdateSpy.callCount).toEqual(1);
         expect(!two.isDirty()).toBe(true);
     });
 });

--- a/packages/fields-storage-ref/__tests__/fields/ref/syncingCurrentInitial.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/ref/syncingCurrentInitial.test.js
@@ -114,11 +114,12 @@ describe("model attribute current / initial values syncing", () => {
                 return { id: ids.two, name: "Two" };
             });
 
-        let saveSpy = sandbox.spy(One.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(One.getStorageDriver(), "create");
+        let updateSpy = sandbox.spy(One.getStorageDriver(), "update");
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
-            .callsFake(() => ids.anotherTwo)
+            .callsFake(() => ids.anotherTwo);
 
         const modelDelete = sandbox.stub(One.getStorageDriver(), "delete").callsFake(() => {
             true;
@@ -147,7 +148,8 @@ describe("model attribute current / initial values syncing", () => {
 
         await one.save();
 
-        expect(saveSpy.callCount).toEqual(2);
+        expect(createSpy.callCount).toEqual(1);
+        expect(updateSpy.callCount).toEqual(1);
         expect(one.id).toEqual(ids.one);
         expect(attrTwo.state.loading).toBe(false);
         expect(attrTwo.state.loaded).toBe(true);
@@ -158,7 +160,8 @@ describe("model attribute current / initial values syncing", () => {
         expect(modelDelete.callCount).toEqual(1);
 
         generateIdStub.restore();
-        saveSpy.restore();
+        createSpy.restore();
+        updateSpy.restore();
         modelDelete.restore();
         modelFindById.restore();
     });

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteDisabledSaveDelete.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteDisabledSaveDelete.test.js
@@ -154,7 +154,7 @@ describe("save and delete models attribute test", () => {
         (await attr2[0].model1Entities)[2].type = "dog";
 
         const AA = mdbid();
-        let saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(mainEntity.getStorageDriver(), "create");
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -162,7 +162,7 @@ describe("save and delete models attribute test", () => {
 
         await mainEntity.save();
 
-        expect(saveSpy.callCount).toEqual(1);
+        expect(createSpy.callCount).toEqual(1);
 
         expect(mainEntity.id).toEqual(AA);
         expect(attr1[0].id).toEqual(null);
@@ -174,7 +174,7 @@ describe("save and delete models attribute test", () => {
         expect((await attr2[1].model1Entities)[0].id).toEqual(null);
         expect(attr2[1].id).toEqual(null);
 
-        saveSpy.restore();
+        createSpy.restore();
         generateIdStub.restore();
     });
 
@@ -194,16 +194,16 @@ describe("save and delete models attribute test", () => {
             .setAutoDelete(false)
             .setAutoSave(false);
 
-        let saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(mainEntity.getStorageDriver(), "create");
 
         let modelFind = sandbox.stub(mainEntity.getStorageDriver(), "find");
 
         await mainEntity.save();
 
-        expect(saveSpy.callCount).toEqual(1);
+        expect(createSpy.callCount).toEqual(1);
         expect(modelFind.callCount).toEqual(0);
 
-        saveSpy.restore();
+        createSpy.restore();
         modelFind.restore();
     });
 
@@ -244,12 +244,12 @@ describe("save and delete models attribute test", () => {
             .setAutoDelete(false)
             .setAutoSave(false);
 
-        let saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(mainEntity.getStorageDriver(), "create");
 
         await mainEntity.save();
 
-        expect(saveSpy.callCount).toEqual(1);
-        saveSpy.restore();
+        expect(createSpy.callCount).toEqual(1);
+        createSpy.restore();
 
         let modelDelete = sandbox.stub(mainEntity.getStorageDriver(), "delete");
         let error = null;

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteManageEntities.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteManageEntities.test.js
@@ -42,7 +42,8 @@ describe("model attribute current / initial values syncing", () => {
 
         const X = mdbid();
 
-        let saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(mainEntity.getStorageDriver(), "create");
+        let updateSpy = sandbox.spy(mainEntity.getStorageDriver(), "update");
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -54,11 +55,13 @@ describe("model attribute current / initial values syncing", () => {
         expect(mainEntity.getField("attribute1").initial[0].id).toEqual(X);
         expect(mainEntity.getField("attribute1").current.length).toBe(1);
         expect(mainEntity.getField("attribute1").current[0].id).toEqual(X);
-        expect(saveSpy.callCount).toEqual(2);
+        expect(createSpy.callCount).toEqual(1);
+        expect(updateSpy.callCount).toEqual(1);
         expect(modelDelete.callCount).toEqual(2);
 
         generateIdStub.restore();
-        saveSpy.restore();
+        createSpy.restore();
+        updateSpy.restore();
         modelFind.restore();
 
         const D = mdbid();
@@ -119,7 +122,7 @@ describe("model attribute current / initial values syncing", () => {
         expect(mainEntity.getField("attribute2").current[1]).toBe(undefined);
         expect(mainEntity.getField("attribute2").current[2]).toBe(undefined);
 
-        saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        updateSpy = sandbox.spy(mainEntity.getStorageDriver(), "update");
         generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -129,10 +132,10 @@ describe("model attribute current / initial values syncing", () => {
         await mainEntity.save();
 
         expect(modelDelete.callCount).toEqual(4);
-        expect(saveSpy.callCount).toEqual(1);
+        expect(updateSpy.callCount).toEqual(1);
 
         modelDelete.restore();
-        saveSpy.restore();
+        updateSpy.restore();
         generateIdStub.restore();
     });
 });

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteSaveDelete.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/autoDeleteSaveDelete.test.js
@@ -153,7 +153,7 @@ describe("save and delete models attribute test", () => {
         const HH = mdbid();
         const II = mdbid();
 
-        let saveSpy = sandbox.spy(mainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(mainEntity.getStorageDriver(), "create");
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(1)
@@ -177,7 +177,7 @@ describe("save and delete models attribute test", () => {
 
         await mainEntity.save();
 
-        expect(saveSpy.callCount).toEqual(9);
+        expect(createSpy.callCount).toEqual(9);
 
         expect(mainEntity.id).toBe(AA);
         expect(attr1[0].id).toBe(BB);
@@ -189,7 +189,7 @@ describe("save and delete models attribute test", () => {
         expect((await attr2[1].model1Entities)[0].id).toBe(II);
         expect(attr2[1].id).toBe(HH);
 
-        saveSpy.restore();
+        createSpy.restore();
         generateIdStub.restore();
     });
 
@@ -200,8 +200,8 @@ describe("save and delete models attribute test", () => {
             new Entity1().populate({ id: null, name: "Bucky", type: "dog" })
         ];
 
-        let modelSave = sandbox
-            .stub(mainEntity.getStorageDriver(), "save")
+        let modelCreate = sandbox
+            .stub(mainEntity.getStorageDriver(), "create")
             .onCall(0)
             .callsFake(model => {
                 model.id = "BB";
@@ -222,10 +222,10 @@ describe("save and delete models attribute test", () => {
 
         await mainEntity.save();
 
-        expect(modelSave.callCount).toEqual(3);
+        expect(modelCreate.callCount).toEqual(3);
         expect(modelFind.callCount).toEqual(0);
 
-        modelSave.restore();
+        modelCreate.restore();
         modelFind.restore();
     });
 
@@ -268,7 +268,7 @@ describe("save and delete models attribute test", () => {
         const HH = mdbid();
         const II = mdbid();
 
-        let saveSpy = sandbox.spy(MainEntity.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(MainEntity.getStorageDriver(), "create");
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -292,8 +292,8 @@ describe("save and delete models attribute test", () => {
 
         await mainEntity.save();
 
-        expect(saveSpy.callCount).toEqual(9);
-        saveSpy.restore();
+        expect(createSpy.callCount).toEqual(9);
+        createSpy.restore();
         generateIdStub.restore();
 
         let modelDelete = sandbox.stub(mainEntity.getStorageDriver(), "delete");

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/autoDeleteLoad.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/autoDeleteLoad.test.js
@@ -98,54 +98,63 @@ describe("attribute models (using an additional aggregation class) - loading tes
 
     test("should not load if values are already set", async () => {
         const user = new User();
-        const modelSave = sandbox.spy(UsersGroups.getStorageDriver(), "save");
+        const modelCreate = sandbox.spy(UsersGroups.getStorageDriver(), "create");
+        const modelUpdate = sandbox.spy(UsersGroups.getStorageDriver(), "update");
         const modelFind = sandbox.spy(UsersGroups.getStorageDriver(), "find");
         const modelFindById = sandbox.spy(UsersGroups.getStorageDriver(), "findOne");
         await user.groups;
 
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user.save();
 
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user.save();
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user.save();
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user.groups;
         await user.save();
 
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         const user2 = new User();
 
         await user2.save();
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user2.save();
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(0);
         expect(modelFindById.callCount).toEqual(0);
 
         await user2.getField('groups').getValue();
         await user2.save();
 
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(1);
         expect(modelFindById.callCount).toEqual(0);
 
@@ -155,7 +164,8 @@ describe("attribute models (using an additional aggregation class) - loading tes
 
         await user2.groups;
 
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelCreate.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(1);
         expect(modelFindById.callCount).toEqual(0);
 
@@ -165,11 +175,13 @@ describe("attribute models (using an additional aggregation class) - loading tes
 
         await user3.groups;
 
-        expect(modelSave.callCount).toEqual(1);
+        expect(modelCreate.callCount).toEqual(1);
+        expect(modelUpdate.callCount).toEqual(0);
         expect(modelFind.callCount).toEqual(2);
         expect(modelFindById.callCount).toEqual(0);
 
-        modelSave.restore();
+        modelCreate.restore();
+        modelUpdate.restore();
         modelFind.restore();
         modelFindById.restore();
     });

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/autoDeleteSave.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/autoDeleteSave.test.js
@@ -71,7 +71,8 @@ describe("attribute models (using an additional aggregation class) - saving test
         expect(user.getField("groups").links.initial).toHaveLength(0);
         expect(user.getField("groups").links.current).toHaveLength(0);
 
-        let saveSpy = sandbox.spy(user.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(user.getStorageDriver(), "create");
+        let updateSpy = sandbox.spy(user.getStorageDriver(), "update");
 
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
@@ -86,10 +87,12 @@ describe("attribute models (using an additional aggregation class) - saving test
 
         await user.save();
 
-        saveSpy.restore();
+        createSpy.restore();
+        updateSpy.restore();
         generateIdStub.restore();
 
-        expect(saveSpy.callCount).toEqual(5);
+        expect(createSpy.callCount).toEqual(4);
+        expect(updateSpy.callCount).toEqual(1);
 
         expect(user.getField("groups").initial).toHaveLength(2);
         expect(user.getField("groups").initial[0].id).toEqual(P);
@@ -120,7 +123,8 @@ describe("attribute models (using an additional aggregation class) - saving test
 
         // Here we care only for save calls that actually created an ID, we don't care about updates. We should have
         // four saves: link for 1st item, link and the item itself for 2nd, and again only link for the last item.
-        saveSpy = sandbox.spy(user.getStorageDriver(), "save");
+        createSpy = sandbox.spy(user.getStorageDriver(), "create");
+        updateSpy = sandbox.spy(user.getStorageDriver(), "update");
         generateIdStub = sandbox
             .stub(idGenerator, "generate")
             .onCall(0)
@@ -133,10 +137,12 @@ describe("attribute models (using an additional aggregation class) - saving test
             .callsFake(() => usersGroups.eighth);
 
         await user.save();
-        saveSpy.restore();
+        createSpy.restore();
+        updateSpy.restore();
         generateIdStub.restore();
 
-        expect(saveSpy.callCount).toEqual(9);
+        expect(createSpy.callCount).toEqual(6);
+        expect(updateSpy.callCount).toEqual(3);
 
         expect(user.getField("groups").initial).toHaveLength(5);
         expect(user.getField("groups").initial[0].id).toEqual(P);
@@ -172,14 +178,14 @@ describe("attribute models (using an additional aggregation class) - saving test
         user.groups = groups;
 
         const modelDelete = sandbox.spy(user.getStorageDriver(), "delete");
-         saveSpy = sandbox.spy(user.getStorageDriver(), "save");
+        updateSpy = sandbox.spy(user.getStorageDriver(), "update");
 
         await user.save();
 
-        expect(saveSpy.callCount).toEqual(4);
+        expect(updateSpy.callCount).toEqual(4);
         expect(modelDelete.callCount).toEqual(2);
 
-        saveSpy.restore();
+        updateSpy.restore();
         modelDelete.restore();
 
         expect(user.getField("groups").initial).toHaveLength(3);
@@ -228,7 +234,8 @@ describe("attribute models (using an additional aggregation class) - saving test
 
         expect(user.getField("groups").state.dirty).toBe(true);
 
-        let modelSaveSpy = sandbox.spy(User.getStorageDriver(), "save");
+        let modelCreateSpy = sandbox.spy(User.getStorageDriver(), "create");
+        let modelUpdateSpy = sandbox.spy(User.getStorageDriver(), "update");
         let modelDeleteSpy = sandbox.spy(User.getStorageDriver(), "delete");
 
         sandbox
@@ -266,7 +273,8 @@ describe("attribute models (using an additional aggregation class) - saving test
 
         await user.save();
 
-        expect(modelSaveSpy.callCount).toEqual(2);
+        expect(modelCreateSpy.callCount).toEqual(1);
+        expect(modelUpdateSpy.callCount).toEqual(1);
         expect(modelDeleteSpy.callCount).toEqual(0);
     });
 
@@ -280,8 +288,8 @@ describe("attribute models (using an additional aggregation class) - saving test
         const user = await UserDynamic.findById(A);
         modelFindById.restore();
 
-        let modelSave = sandbox
-            .stub(user.getStorageDriver(), "save")
+        let modelUpdate = sandbox
+            .stub(user.getStorageDriver(), "update")
             .onCall(0)
             .callsFake(() => {
                 return true;
@@ -291,12 +299,12 @@ describe("attribute models (using an additional aggregation class) - saving test
                 return true;
             });
         await user.save();
-        expect(modelSave.callCount).toEqual(0);
+        expect(modelUpdate.callCount).toEqual(0);
 
         user.name = "now it should save because of this dirty attribute";
         await user.save();
-        modelSave.restore();
-        expect(modelSave.callCount).toEqual(1);
+        modelUpdate.restore();
+        expect(modelUpdate.callCount).toEqual(1);
 
         let modelDelete = sandbox
             .stub(user.getStorageDriver(), "delete")

--- a/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/loadingEntities.test.js
+++ b/packages/fields-storage-ref/__tests__/fields/refList/withoutStorage/using/loadingEntities.test.js
@@ -133,7 +133,8 @@ describe("save and delete models attribute test", () => {
         expect(user.getField("groups").state.loading).toBe(false);
         expect(user.getField("groups").state.loaded).toBe(false);
 
-        let saveSpy = sandbox.spy(user.getStorageDriver(), "save");
+        let createSpy = sandbox.spy(user.getStorageDriver(), "create");
+        let updateSpy = sandbox.spy(user.getStorageDriver(), "update");
 
         let generateIdStub = sandbox
             .stub(idGenerator, "generate")
@@ -148,7 +149,8 @@ describe("save and delete models attribute test", () => {
 
         await user.save();
 
-        expect(saveSpy.callCount).toEqual(5);
+        expect(createSpy.callCount).toEqual(4);
+        expect(updateSpy.callCount).toEqual(1);
 
         expect(user.getField("groups").initial).toHaveLength(2);
         expect(user.getField("groups").initial[0].id).toEqual(P);
@@ -165,7 +167,8 @@ describe("save and delete models attribute test", () => {
         expect(user.getField("groups").links.current[0].id).toEqual(fourth);
         expect(user.getField("groups").links.current[1].id).toEqual(fifth);
 
-        saveSpy.restore();
+        createSpy.restore();
+        updateSpy.restore();
         generateIdStub.restore();
     });
 });

--- a/packages/fields-storage-ref/__tests__/resources/CustomDriver/CustomDriver.js
+++ b/packages/fields-storage-ref/__tests__/resources/CustomDriver/CustomDriver.js
@@ -3,39 +3,41 @@ class CustomDriver {
         this.data = {};
     }
 
-    async save({ name, data, isCreate }) {
-        const method = isCreate ? "create" : "update";
-        return this[method]({ name, data });
+    async create(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
+
+            this.data[name][data.id] = data;
+        }
     }
 
-    async create({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
-        }
+    async update(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
 
-        this.data[name][data.id] = data;
+            this.data[name][data.id] = data;
+        }
     }
 
-    async update({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
+    async delete(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                continue;
+            }
+
+            if (!this.data[name][data.id]) {
+                continue;
+            }
+
+            delete this.data[name][data.id];
         }
-
-        this.data[name][data.id] = data;
-    }
-
-    async delete({ name, data }) {
-        if (!this.data[name]) {
-            return;
-        }
-
-        if (!this.data[name][data.id]) {
-            return;
-        }
-
-        delete this.data[name][data.id];
     }
 
     async count({ name, options }) {

--- a/packages/fields-storage-soft-delete/__tests__/resources/CustomDriver/CustomDriver.js
+++ b/packages/fields-storage-soft-delete/__tests__/resources/CustomDriver/CustomDriver.js
@@ -3,39 +3,41 @@ class CustomDriver {
         this.data = {};
     }
 
-    async save({ name, data, isCreate }) {
-        const method = isCreate ? "create" : "update";
-        return this[method]({ name, data });
+    async create(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
+
+            this.data[name][data.id] = data;
+        }
     }
 
-    async create({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
-        }
+    async update(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
 
-        this.data[name][data.id] = data;
+            this.data[name][data.id] = data;
+        }
     }
 
-    async update({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
+    async delete(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                continue;
+            }
+
+            if (!this.data[name][data.id]) {
+                continue;
+            }
+
+            delete this.data[name][data.id];
         }
-
-        this.data[name][data.id] = data;
-    }
-
-    async delete({ name, data }) {
-        if (!this.data[name]) {
-            return;
-        }
-
-        if (!this.data[name][data.id]) {
-            return;
-        }
-
-        delete this.data[name][data.id];
     }
 
     async count({ name, options }) {

--- a/packages/fields-storage-soft-delete/src/withSoftDelete.js
+++ b/packages/fields-storage-soft-delete/src/withSoftDelete.js
@@ -31,14 +31,16 @@ export default () => {
                     await this.hook("beforeDelete", { options, model: this });
 
                     this.deleted = true;
-                    await this.getStorageDriver().save({
-                        name: getName(this),
-                        data: {
-                            ...(await this.toStorage()),
-                            id: this.id
-                        },
-                        options
-                    });
+                    await this.getStorageDriver().update([
+                        {
+                            name: getName(this),
+                            data: {
+                                ...(await this.toStorage()),
+                                id: this.id
+                            },
+                            options
+                        }
+                    ]);
 
                     await this.hook("afterDelete", { options, model: this });
 

--- a/packages/fields-storage/__tests__/multipleDeleteSavePrevention.test.js
+++ b/packages/fields-storage/__tests__/multipleDeleteSavePrevention.test.js
@@ -16,7 +16,7 @@ describe("multiple delete / save prevention test", () => {
 
     test("should only call save once", async () => {
         const user = new User();
-        const save = sandbox.spy(User.getStorageDriver(), "save");
+        const save = sandbox.spy(User.getStorageDriver(), "update");
 
         const promise = user.save();
         user.save();

--- a/packages/fields-storage/__tests__/resources/CustomDriver/CustomDriver.js
+++ b/packages/fields-storage/__tests__/resources/CustomDriver/CustomDriver.js
@@ -3,39 +3,41 @@ class CustomDriver {
         this.data = {};
     }
 
-    async save({ name, data, isCreate }) {
-        const method = isCreate ? "create" : "update";
-        return this[method]({ name, data });
+    async create(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
+
+            this.data[name][data.id] = data;
+        }
     }
 
-    async create({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
-        }
+    async update(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                this.data[name] = {};
+            }
 
-        this.data[name][data.id] = data;
+            this.data[name][data.id] = data;
+        }
     }
 
-    async update({ name, data }) {
-        // Check if table exists.
-        if (!this.data[name]) {
-            this.data[name] = {};
+    async delete(items) {
+        for (let i = 0; i < items.length; i++) {
+            const { name, data } = items[i];
+            if (!this.data[name]) {
+                continue;
+            }
+
+            if (!this.data[name][data.id]) {
+                continue;
+            }
+
+            delete this.data[name][data.id];
         }
-
-        this.data[name][data.id] = data;
-    }
-
-    async delete({ name, data }) {
-        if (!this.data[name]) {
-            return;
-        }
-
-        if (!this.data[name][data.id]) {
-            return;
-        }
-
-        delete this.data[name][data.id];
     }
 
     async count({ name, options }) {

--- a/packages/fields-storage/__tests__/setOnce.test.js
+++ b/packages/fields-storage/__tests__/setOnce.test.js
@@ -17,13 +17,11 @@ describe("setOnce test", () => {
             })
         )(createModel());
 
-        let modelFindById = sandbox
-            .stub(SomeModel.getStorageDriver(), "findOne")
-            .callsFake(() => ({
-                id,
-                slug: "slug-test",
-                name: "name-test"
-            }));
+        let modelFindById = sandbox.stub(SomeModel.getStorageDriver(), "findOne").callsFake(() => ({
+            id,
+            slug: "slug-test",
+            name: "name-test"
+        }));
 
         const someModel1 = await SomeModel.findById(id);
 
@@ -35,7 +33,7 @@ describe("setOnce test", () => {
 
         // Changing the slug and saving it to the database should not work
         // Slug should not change because of a "setOnce" call.
-        let saveSpy = sandbox.spy(someModel1.getStorageDriver(), "save");
+        let saveSpy = sandbox.spy(someModel1.getStorageDriver(), "update");
 
         someModel1.slug = "slug-test-2";
         await someModel1.save();
@@ -46,14 +44,14 @@ describe("setOnce test", () => {
         await someModel1.save();
 
         expect(saveSpy.callCount).toEqual(1);
-        expect(saveSpy.getCall(0).args[0]).toEqual({
-            data: {
-                id: id,
-                name: "name-test-2"
-            },
-            isCreate: false,
-            isUpdate: true,
-            name: "SomeModel"
-        });
+        expect(saveSpy.getCall(0).args[0]).toEqual([
+            {
+                data: {
+                    id: id,
+                    name: "name-test-2"
+                },
+                name: "SomeModel"
+            }
+        ]);
     });
 });

--- a/packages/fields-storage/__tests__/storagePool.test.js
+++ b/packages/fields-storage/__tests__/storagePool.test.js
@@ -12,8 +12,8 @@ describe("model pool test", () => {
         const A = mdbid();
         const user = new User();
         user.age = 30;
-        sandbox.stub(user.getStorageDriver(), "save").callsFake(({ data }) => {
-            data.id = A;
+        sandbox.stub(user.getStorageDriver(), "create").callsFake((items) => {
+            items[0].data.id = A;
             return true;
         });
 

--- a/packages/fields-storage/src/withStorage.js
+++ b/packages/fields-storage/src/withStorage.js
@@ -134,15 +134,15 @@ const withStorage = (configuration: Configuration) => {
                             this.id = this.constructor.generateId();
                         }
 
-                        await this.getStorageDriver().save({
-                            name: getName(this),
-                            isUpdate: existing,
-                            isCreate: !existing,
-                            data: {
-                                ...(await this.toStorage()),
-                                id: this.id
+                        await this.getStorageDriver()[existing ? "update" : "create"]([
+                            {
+                                name: getName(this),
+                                data: {
+                                    ...(await this.toStorage()),
+                                    id: this.id
+                                }
                             }
-                        });
+                        ]);
                     }
 
                     await registerSaveUpdateCreateHooks("__after", {
@@ -187,11 +187,13 @@ const withStorage = (configuration: Configuration) => {
 
                     await this.hook("beforeDelete", { options, model: this });
 
-                    await this.getStorageDriver().delete({
-                        name: getName(this),
-                        data: { id: this.id },
-                        options
-                    });
+                    await this.getStorageDriver().delete([
+                        {
+                            name: getName(this),
+                            data: { id: this.id },
+                            options
+                        }
+                    ]);
 
                     await this.hook("afterDelete", { options, model: this });
 


### PR DESCRIPTION
This PR introduces a breaking change to the `fields-storage-mongodb` by changing `create`, `update` and `delete` method signatures. With the new approach we're able to pass multiple items for processing to each of the aforementioned methods.

## Example usage
```js
await driver.update([{ name, data }, { name, data }]);
```

## How has this been tested?
Tested using Jest tests. The whole repository has been updated to use this new interface and tests were updated accordingly.

