### PR TITLE
Fix field validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import { withFields, string, number, boolean } from "@commodo/fields";
 
 const Animal = withFields({
     name: string({
-        validate: value => {
+        validation: value => {
             if (!value) {
                 throw Error("A pet must have a name!");
             }


### PR DESCRIPTION
I believe in the simple data model example, `validation` function should be used instead of `validate`